### PR TITLE
Chore: Upload immediately on max items reached

### DIFF
--- a/index.js
+++ b/index.js
@@ -93,7 +93,6 @@ WinstonDynamoDB.prototype.log = function (info, callback) {
 };
 
 WinstonDynamoDB.prototype.createUploadInterval = function() {
-    debug('creating interval');
     this.intervalId = setInterval(() => {
         this.submit();
     }, this.uploadRate);
@@ -111,12 +110,14 @@ WinstonDynamoDB.prototype.add = function(log) {
 
     // When we reach maximum amount of items in batch, reschedule
     if (this.logEvents.length >= dynamodbIntegration.MAX_BATCH_ITEM_NUM) {
+        debug('Max items for batch reached - submitting and rescheduling interval');
         clearInterval(this.intervalId);
         this.createUploadInterval();
         this.submit();
     }
 
     if (!this.intervalId) {
+        debug('creating interval');
         this.createUploadInterval()
     }
 };
@@ -128,7 +129,6 @@ WinstonDynamoDB.prototype.submit = function(callback) {
             this.errorHandler ? this.errorHandler(err) : console.error(err);
         }
     }
-
     callback = callback || defaultCallback;
 
     const streamName = typeof this.logStreamName === 'function' ?

--- a/index.js
+++ b/index.js
@@ -129,6 +129,8 @@ WinstonDynamoDB.prototype.submit = function(callback) {
         }
     }
 
+    callback = callback || defaultCallback;
+
     const streamName = typeof this.logStreamName === 'function' ?
         this.logStreamName() : this.logStreamName;
 
@@ -142,7 +144,7 @@ WinstonDynamoDB.prototype.submit = function(callback) {
         streamName,
         this.logEvents,
         this.options,
-        callback || defaultCallback
+        callback
     );
 };
 

--- a/index.js
+++ b/index.js
@@ -142,7 +142,7 @@ WinstonDynamoDB.prototype.submit = function(callback) {
         streamName,
         this.logEvents,
         this.options,
-        callback ?? defaultCallback
+        callback || defaultCallback
     );
 };
 

--- a/lib/dynamodb-integration.js
+++ b/lib/dynamodb-integration.js
@@ -1,7 +1,6 @@
 const LIMITS = {
     MAX_EVENT_MSG_SIZE_BYTES: 400000,   // The real max size is 409,600, we leave some room for overhead on each message
     MAX_BATCH_SIZE_BYTES: 16000000,     // We leave some fudge factor here too. This shouldn't be reachable for 25 items, however.
-    MAX_BATCH_ITEM_NUM: 25
 }
 
 // CloudWatch adds 26. DynamoDB doesn't, but we wanna add a constant size to each item
@@ -10,12 +9,12 @@ const BASE_EVENT_SIZE_BYTES = 26;
 
 const debug = require('./utils').debug;
 
-const lib = {};
+const lib = { MAX_BATCH_ITEM_NUM: 25 };
 
 const popEventsToSend = (logEvents, cb) => {
     var entryIndex = 0;
     var bytes = 0;
-    while (entryIndex < Math.min(logEvents.length, LIMITS.MAX_BATCH_ITEM_NUM)) {
+    while (entryIndex < Math.min(logEvents.length, lib.MAX_BATCH_ITEM_NUM)) {
         var ev = logEvents[entryIndex];
         // unit tests pass null elements
         var evSize = ev ? Buffer.byteLength(ev.message, 'utf8') + BASE_EVENT_SIZE_BYTES : 0;

--- a/lib/dynamodb-integration.js
+++ b/lib/dynamodb-integration.js
@@ -63,7 +63,7 @@ lib.upload = function(aws, tableName, streamName, logEvents, options, cb) {
     const eventsToSend = popEventsToSend(logEvents, cb);
     const payload = buildPayload(tableName, streamName, eventsToSend);
 
-    debug('send to aws', payload);
+    debug('send to aws');
     aws.batchWriteItem(payload, function(err, data) {
         debug('sent to aws, err: ', err, ' data: ', data)
         if (err) {
@@ -73,7 +73,6 @@ lib.upload = function(aws, tableName, streamName, logEvents, options, cb) {
             cb()
         }
     });
-    debug('after');
 
 };
 

--- a/lib/dynamodb-integration.js
+++ b/lib/dynamodb-integration.js
@@ -74,6 +74,7 @@ lib.upload = function(aws, tableName, streamName, logEvents, options, cb) {
             cb()
         }
     });
+    debug('after');
 
 };
 


### PR DESCRIPTION
Resolves https://github.com/env0/winston-aws-dynamodb/issues/5

If 25 events are in the queue, then immediately reschedule the interval, and submit (submitting synchronously immediately removes the events from the queue)