### PR TITLE
Pass DynamoDB client as parameter to the transport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+### v3.0.0
+#### Breacking Changes
+Pass the DynamoDB client instance to the constructor instead of creating it inside the class.

--- a/package.json
+++ b/package.json
@@ -7,24 +7,21 @@
     "type": "git",
     "url": "git+https://github.com/env0/winston-aws-dynamodb.git"
   },
-  "author": "",
-  "license": "ISC",
+  "author": "env0",
+  "private": true,
   "bugs": {
     "url": "https://github.com/env0/winston-aws-dynamodb/issues"
   },
   "homepage": "https://github.com/env0/winston-aws-dynamodb#readme",
   "peerDependencies": {
     "winston": "^3.0.0",
-    "@aws-sdk/client-dynamodb": "^3.485.0",
-    "@smithy/node-http-handler": "^2.2.2"
+    "@aws-sdk/client-dynamodb": "^3.540.0"
   },
   "dependencies": {
     "chalk": "^4.1.1",
     "fast-safe-stringify": "^2.0.7",
-    "lodash.assign": "^4.2.0",
     "lodash.isempty": "^4.4.0",
     "lodash.iserror": "^3.1.1",
-    "lodash.isundefined": "^3.0.1",
-    "proxy-agent": "^4.0.1"
+    "lodash.isundefined": "^3.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "winston-aws-dynamodb",
-  "version": "2.0.1",
+  "version": "3.0.0",
   "description": "Winston Transport for DynamoDB",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
We have an utility that knows how to configure the DynamoDB client, and we don't want to duplicate this code here, so just pass the client instance to the transport.