### PR TITLE
Chore: split long messages before sending them

### DIFF
--- a/index.js
+++ b/index.js
@@ -72,7 +72,7 @@ WinstonDynamoDB.prototype.add = function (log) {
     const { message: originalMessage } = log;
 
     if (originalMessage.length <= maxMessageLength) {
-        if (isEmpty(originalMessage) || isError(originalMessage)) {
+        if (!isEmpty(originalMessage) || isError(originalMessage)) {
             this.logEvents.push({
                 message: this.formatMessage(log),
                 timestamp: process.hrtime.bigint(),

--- a/index.js
+++ b/index.js
@@ -45,8 +45,13 @@ WinstonDynamoDB.prototype.log = function (info, callback) {
     if (!isEmpty(info.message) || isError(info.message)) {
         const { message } = info
 
-        for (let i = 0; i < message.length; i += maximalMessageLength) {
-            this.log({ ...info, message: message.slice(i, i + maximalMessageLength) }, () => {});
+        if (message.length < maximalMessageLength) {
+            this.add(info);
+        }
+        else {
+            for (let i = 0; i < message.length; i += maximalMessageLength) {
+                this.log({ ...info, message: message.slice(i, i + maximalMessageLength) }, () => {});
+            }
         }
     }
 

--- a/index.js
+++ b/index.js
@@ -111,7 +111,7 @@ WinstonDynamoDB.prototype.submit = function (callback) {
         this.logStreamName() : this.logStreamName;
 
     if (isEmpty(this.logEvents)) {
-        return callback();
+        return callback(null, true);
     }
 
     dynamodbIntegration.upload(

--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ const
     stringify = require('./lib/utils').stringify,
     debug = require('./lib/utils').debug,
     defaultFlushTimeoutMs = 10_000,
+    // we chose that as we wish to keep the message size under 400KB, to avoid truncation, and it should be enough as a safety net
     maxMessageLength = 300_000;
 
 const WinstonDynamoDB = function (options) {

--- a/index.js
+++ b/index.js
@@ -45,7 +45,7 @@ WinstonDynamoDB.prototype.log = function (info, callback) {
     if (!isEmpty(info.message) || isError(info.message)) {
         const { message } = info
 
-        if (message.length < maximalMessageLength) {
+        if (message.length <= maximalMessageLength) {
             this.add(info);
         }
         else {

--- a/index.js
+++ b/index.js
@@ -72,14 +72,19 @@ WinstonDynamoDB.prototype.add = function (log) {
 
     const { message: originalMessage } = log;
 
-    if (originalMessage.length <= maxMessageLength) {
-        if (!isEmpty(originalMessage) || isError(originalMessage)) {
-            this.logEvents.push({
-                message: this.formatMessage(log),
-                timestamp: process.hrtime.bigint(),
-                rawMessage: log
-            });
-        }
+    if (isEmpty(originalMessage) || isError(originalMessage)) {
+        this.logEvents.push({
+            message: this.formatMessage(log),
+            timestamp: process.hrtime.bigint(),
+            rawMessage: log
+        });
+    }
+    else if (originalMessage.length <= maxMessageLength) {
+        this.logEvents.push({
+            message: this.formatMessage(log),
+            timestamp: process.hrtime.bigint(),
+            rawMessage: log
+        });
 
         if (this.logEvents.length >= dynamodbIntegration.MAX_BATCH_ITEM_NUM) {
             debug('Max items for batch reached - submitting and rescheduling interval');
@@ -87,7 +92,8 @@ WinstonDynamoDB.prototype.add = function (log) {
             this.createUploadInterval();
             this.submit();
         }
-    } else {
+    }
+    else {
         for (let i = 0; i < originalMessage.length; i += maxMessageLength) {
             let currentMessageSlice = originalMessage.slice(i, i + maxMessageLength);
             this.logEvents.push({

--- a/index.js
+++ b/index.js
@@ -45,7 +45,7 @@ WinstonDynamoDB.prototype.log = function (info, callback) {
     if (!isEmpty(info.message) || isError(info.message)) {
         const { message } = info
 
-        if (message.length <= maximalMessageLength) {
+        if (message.length < maximalMessageLength) {
             this.add(info);
         }
         else {

--- a/index.js
+++ b/index.js
@@ -46,7 +46,7 @@ WinstonDynamoDB.prototype.log = function (info, callback) {
         const { message } = info
 
         for (let i = 0; i < message.length; i += maximalMessageLength) {
-            this.log({ ...info, message: message.slice(i, i + maximalMessageLength) }, () => {});
+            this.add({ ...info, message: message.slice(i, i + maximalMessageLength) });
         }
     }
 

--- a/index.js
+++ b/index.js
@@ -45,13 +45,8 @@ WinstonDynamoDB.prototype.log = function (info, callback) {
     if (!isEmpty(info.message) || isError(info.message)) {
         const { message } = info
 
-        if (message.length < maximalMessageLength) {
-            this.add(info);
-        }
-        else {
-            for (let i = 0; i < message.length; i += maximalMessageLength) {
-                this.log({ ...info, message: message.slice(i, i + maximalMessageLength) }, () => {});
-            }
+        for (let i = 0; i < message.length; i += maximalMessageLength) {
+            this.log({ ...info, message: message.slice(i, i + maximalMessageLength) }, () => {});
         }
     }
 

--- a/index.js
+++ b/index.js
@@ -8,8 +8,7 @@ const
     isError = require('lodash.iserror'),
     stringify = require('./lib/utils').stringify,
     debug = require('./lib/utils').debug,
-    defaultFlushTimeoutMs = 10_000,
-    maximalMessageLength = 10_000;
+    defaultFlushTimeoutMs = 10000;
 
 const WinstonDynamoDB = function (options) {
     winston.Transport.call(this, options);
@@ -43,11 +42,7 @@ WinstonDynamoDB.prototype.log = function (info, callback) {
     debug('log (called by winston)', info);
 
     if (!isEmpty(info.message) || isError(info.message)) {
-        const { message } = info
-
-        for (let i = 0; i < message.length; i += maximalMessageLength) {
-            this.add({ ...info, message: message.slice(i, i + maximalMessageLength) });
-        }
+        this.add(info);
     }
 
     if (!/^uncaughtException: /.test(info.message)) {

--- a/index.js
+++ b/index.js
@@ -38,37 +38,25 @@ const WinstonDynamoDB = function (options) {
 
 util.inherits(WinstonDynamoDB, winston.Transport);
 
-
-
 WinstonDynamoDB.prototype.log = function (info, callback) {
-    const  internalLog = (info, callback) => {
-        debug('log (called by winston)', info);
+    debug('log (called by winston)', info);
 
-        if (!isEmpty(info.message) || isError(info.message)) {
-            this.add(info);
-        }
-
-        if (!/^uncaughtException: /.test(info.message)) {
-            // do not wait, just return right away
-            return callback(null, true);
-        }
-
-        debug('message not empty, proceeding')
-
-        // clear interval and send logs immediately
-        // as Winston is about to end the process
-        clearInterval(this.intervalId);
-        this.intervalId = null;
-        this.submit(callback);
+    if (!isEmpty(info.message) || isError(info.message)) {
+        this.add(info);
     }
 
-    const { message } = info;
-
-    for (let i = 0; i < message.length; i+=10_000) {
-        internalLog({ ...info, message: message.slice(i, i+10_000) }, () => {});
+    if (!/^uncaughtException: /.test(info.message)) {
+        // do not wait, just return right away
+        return callback(null, true);
     }
 
-    callback();
+    debug('message not empty, proceeding')
+
+    // clear interval and send logs immediately
+    // as Winston is about to end the process
+    clearInterval(this.intervalId);
+    this.intervalId = null;
+    this.submit(callback);
 };
 
 WinstonDynamoDB.prototype.createUploadInterval = function () {

--- a/index.js
+++ b/index.js
@@ -46,7 +46,7 @@ WinstonDynamoDB.prototype.log = function (info, callback) {
         const { message } = info
 
         for (let i = 0; i < message.length; i += maximalMessageLength) {
-            this.add({ ...info, message: message.slice(i, i + maximalMessageLength) });
+            this.log({ ...info, message: message.slice(i, i + maximalMessageLength) }, () => {});
         }
     }
 

--- a/index.js
+++ b/index.js
@@ -72,41 +72,25 @@ WinstonDynamoDB.prototype.add = function (log) {
 
     const { message: originalMessage } = log;
 
-    if (isEmpty(originalMessage) || isError(originalMessage)) {
-        this.logEvents.push({
-            message: this.formatMessage(log),
-            timestamp: process.hrtime.bigint(),
-            rawMessage: log
-        });
-    }
-    else if (originalMessage.length <= maxMessageLength) {
-        this.logEvents.push({
-            message: this.formatMessage(log),
-            timestamp: process.hrtime.bigint(),
-            rawMessage: log
-        });
-
-        if (this.logEvents.length >= dynamodbIntegration.MAX_BATCH_ITEM_NUM) {
-            debug('Max items for batch reached - submitting and rescheduling interval');
-            clearInterval(this.intervalId);
-            this.createUploadInterval();
-            this.submit();
-        }
-    }
-    else {
+    if (!isEmpty(originalMessage) || isError(originalMessage)) {
         for (let i = 0; i < originalMessage.length; i += maxMessageLength) {
             let currentMessageSlice = originalMessage.slice(i, i + maxMessageLength);
+
             this.logEvents.push({
                 message: this.formatMessage({...log, message: currentMessageSlice}),
                 timestamp: process.hrtime.bigint(),
                 rawMessage: log
             });
 
-            debug(`Send each slice individually right away. current slice number:  ${(i / maxMessageLength) + 1}`);
-            clearInterval(this.intervalId);
-            this.createUploadInterval();
-            this.submit();
+            debug(`Send current slice number:  ${(i / maxMessageLength) + 1}`);
         }
+    }
+
+    if (this.logEvents.length >= dynamodbIntegration.MAX_BATCH_ITEM_NUM) {
+        debug('Max items for batch reached - submitting and rescheduling interval');
+        clearInterval(this.intervalId);
+        this.createUploadInterval();
+        this.submit();
     }
 
     if (!this.intervalId) {

--- a/index.js
+++ b/index.js
@@ -121,7 +121,7 @@ WinstonDynamoDB.prototype.submit = function (callback) {
         this.logStreamName() : this.logStreamName;
 
     if (isEmpty(this.logEvents)) {
-        return callback(null, true);
+        return callback();
     }
 
     dynamodbIntegration.upload(

--- a/lib/dynamodb-integration.js
+++ b/lib/dynamodb-integration.js
@@ -86,7 +86,7 @@ lib.upload = function(dynamodbClient, tableName, streamName, logEvents, options,
             debug('error during batchWriteItem', err, true)
             retrySubmit(dynamodbClient, payload, 3, cb)
         } else {
-            cb(null, true)
+            cb()
         }
     });
 };

--- a/lib/dynamodb-integration.js
+++ b/lib/dynamodb-integration.js
@@ -1,7 +1,9 @@
 const { BatchWriteItemCommand } = require('@aws-sdk/client-dynamodb');
 var isUndefined = require('lodash.isundefined');
+var isEmpty = require('lodash.isempty');
 
 const LIMITS = {
+    MAX_EVENT_MSG_SIZE_BYTES: 400000,   // The real max size is 409,600, we leave some room for overhead on each message
     MAX_BATCH_SIZE_BYTES: 16000000,     // We leave some fudge factor here too. This shouldn't be reachable for 25 items, however.
 }
 
@@ -13,7 +15,7 @@ const debug = require('./utils').debug;
 
 const lib = { MAX_BATCH_ITEM_NUM: 25 };
 
-const popEventsToSend = (logEvents, cb) => {
+const popEventsToSend = (logEvents) => {
     var entryIndex = 0;
     var bytes = 0;
     while (entryIndex < Math.min(logEvents.length, lib.MAX_BATCH_ITEM_NUM)) {
@@ -68,20 +70,27 @@ const buildPayload = (tableName, streamName, events, additionalAttributesSchema 
 lib.upload = function(dynamodbClient, tableName, streamName, logEvents, options, cb) {
     debug('upload', logEvents);
 
-    const eventsToSend = popEventsToSend(logEvents, cb);
-    const payload = buildPayload(tableName, streamName, eventsToSend, options.additionalAttributesSchema);
+    let isError = false;
 
-    debug('send to aws');
+    while (!isEmpty(logEvents)){
+        const eventsToSend = popEventsToSend(logEvents); // changes logEvents in place
+        const payload = buildPayload(tableName, streamName, eventsToSend, options.additionalAttributesSchema);
 
-    dynamodbClient.send(new BatchWriteItemCommand(payload), function (err, data) {
-        debug('sent to aws, err: ', err, ' data: ', data)
-        if (err) {
-            debug('error during batchWriteItem', err, true)
-            retrySubmit(dynamodbClient, payload, 3, cb)
-        } else {
-            cb()
-        }
-    });
+        debug('send to aws');
+
+        dynamodbClient.send(new BatchWriteItemCommand(payload), function (err, data) {
+            debug('sent to aws, err: ', err, ' data: ', data)
+            if (err) {
+                debug('error during batchWriteItem', err, true)
+                retrySubmit(dynamodbClient, payload, 3, cb)
+                isError = true;
+            }
+        });
+    }
+
+    if (!isError) { // cb is called if error occurs, can only be called once
+        cb();
+    }
 };
 
 function retrySubmit(dynamodbClient, payload, times, cb) {

--- a/lib/dynamodb-integration.js
+++ b/lib/dynamodb-integration.js
@@ -1,9 +1,7 @@
 const { BatchWriteItemCommand } = require('@aws-sdk/client-dynamodb');
 var isUndefined = require('lodash.isundefined');
-var isEmpty = require('lodash.isempty');
 
 const LIMITS = {
-    MAX_EVENT_MSG_SIZE_BYTES: 400000,   // The real max size is 409,600, we leave some room for overhead on each message
     MAX_BATCH_SIZE_BYTES: 16000000,     // We leave some fudge factor here too. This shouldn't be reachable for 25 items, however.
 }
 
@@ -15,7 +13,7 @@ const debug = require('./utils').debug;
 
 const lib = { MAX_BATCH_ITEM_NUM: 25 };
 
-const popEventsToSend = (logEvents) => {
+const popEventsToSend = (logEvents, cb) => {
     var entryIndex = 0;
     var bytes = 0;
     while (entryIndex < Math.min(logEvents.length, lib.MAX_BATCH_ITEM_NUM)) {
@@ -70,27 +68,20 @@ const buildPayload = (tableName, streamName, events, additionalAttributesSchema 
 lib.upload = function(dynamodbClient, tableName, streamName, logEvents, options, cb) {
     debug('upload', logEvents);
 
-    let isError = false;
+    const eventsToSend = popEventsToSend(logEvents, cb);
+    const payload = buildPayload(tableName, streamName, eventsToSend, options.additionalAttributesSchema);
 
-    while (!isEmpty(logEvents)){
-        const eventsToSend = popEventsToSend(logEvents); // changes logEvents in place
-        const payload = buildPayload(tableName, streamName, eventsToSend, options.additionalAttributesSchema);
+    debug('send to aws');
 
-        debug('send to aws');
-
-        dynamodbClient.send(new BatchWriteItemCommand(payload), function (err, data) {
-            debug('sent to aws, err: ', err, ' data: ', data)
-            if (err) {
-                debug('error during batchWriteItem', err, true)
-                retrySubmit(dynamodbClient, payload, 3, cb)
-                isError = true;
-            }
-        });
-    }
-
-    if (!isError) { // cb is called if error occurs, can only be called once
-        cb();
-    }
+    dynamodbClient.send(new BatchWriteItemCommand(payload), function (err, data) {
+        debug('sent to aws, err: ', err, ' data: ', data)
+        if (err) {
+            debug('error during batchWriteItem', err, true)
+            retrySubmit(dynamodbClient, payload, 3, cb)
+        } else {
+            cb()
+        }
+    });
 };
 
 function retrySubmit(dynamodbClient, payload, times, cb) {

--- a/lib/dynamodb-integration.js
+++ b/lib/dynamodb-integration.js
@@ -86,7 +86,7 @@ lib.upload = function(dynamodbClient, tableName, streamName, logEvents, options,
             debug('error during batchWriteItem', err, true)
             retrySubmit(dynamodbClient, payload, 3, cb)
         } else {
-            cb()
+            cb(null, true)
         }
     });
 };

--- a/lib/dynamodb-integration.js
+++ b/lib/dynamodb-integration.js
@@ -2,7 +2,6 @@ const { BatchWriteItemCommand } = require('@aws-sdk/client-dynamodb');
 var isUndefined = require('lodash.isundefined');
 
 const LIMITS = {
-    MAX_EVENT_MSG_SIZE_BYTES: 400000,   // The real max size is 409,600, we leave some room for overhead on each message
     MAX_BATCH_SIZE_BYTES: 16000000,     // We leave some fudge factor here too. This shouldn't be reachable for 25 items, however.
 }
 
@@ -21,13 +20,7 @@ const popEventsToSend = (logEvents, cb) => {
         var ev = logEvents[entryIndex];
         // unit tests pass null elements
         var evSize = ev ? Buffer.byteLength(ev.message, 'utf8') + BASE_EVENT_SIZE_BYTES : 0;
-        if(evSize > LIMITS.MAX_EVENT_MSG_SIZE_BYTES) {
-            evSize = LIMITS.MAX_EVENT_MSG_SIZE_BYTES;
-            ev.message = ev.message.substring(0, evSize);
-            const msgTooBigErr = new Error('Message Truncated because it exceeds the DynamoDB size limit');
-            msgTooBigErr.logEvent = ev;
-            cb(msgTooBigErr);
-        }
+
         if (bytes + evSize > LIMITS.MAX_BATCH_SIZE_BYTES) break;
         bytes += evSize;
         entryIndex++;

--- a/lib/dynamodb-integration.js
+++ b/lib/dynamodb-integration.js
@@ -2,6 +2,7 @@ const { BatchWriteItemCommand } = require('@aws-sdk/client-dynamodb');
 var isUndefined = require('lodash.isundefined');
 
 const LIMITS = {
+    MAX_EVENT_MSG_SIZE_BYTES: 400000,   // The real max size is 409,600, we leave some room for overhead on each message
     MAX_BATCH_SIZE_BYTES: 16000000,     // We leave some fudge factor here too. This shouldn't be reachable for 25 items, however.
 }
 
@@ -20,7 +21,13 @@ const popEventsToSend = (logEvents, cb) => {
         var ev = logEvents[entryIndex];
         // unit tests pass null elements
         var evSize = ev ? Buffer.byteLength(ev.message, 'utf8') + BASE_EVENT_SIZE_BYTES : 0;
-
+        if(evSize > LIMITS.MAX_EVENT_MSG_SIZE_BYTES) {
+            evSize = LIMITS.MAX_EVENT_MSG_SIZE_BYTES;
+            ev.message = ev.message.substring(0, evSize);
+            const msgTooBigErr = new Error('Message Truncated because it exceeds the DynamoDB size limit');
+            msgTooBigErr.logEvent = ev;
+            cb(msgTooBigErr);
+        }
         if (bytes + evSize > LIMITS.MAX_BATCH_SIZE_BYTES) break;
         bytes += evSize;
         entryIndex++;


### PR DESCRIPTION
sending long messages can cause problems when fetching the logged data in DDB, such as infinite loops of fetching data due to not being able to fetch the actual log and the pagination mechanism gets broken.

solution:
split the messages to 300k length chunks and log each of them individually

qa:
in the PR env that uses that new version I deployed logs with short messages, and long messages that required splitting, and saw all gets logged correctly, during deployment, and after the deployment has ended