### PR TITLE
Fix: Make transporter more resilient

### DIFF
--- a/lib/dynamodb-integration.js
+++ b/lib/dynamodb-integration.js
@@ -8,7 +8,7 @@ import { debug } from './utils.js';
 const LIMITS = {
   MAX_EVENT_MSG_SIZE_BYTES: 400000,   // The real max size is 409,600, we leave some room for overhead on each message
   MAX_BATCH_SIZE_BYTES: 16000000,     // We leave some fudge factor here too. This shouldn't be reachable for 25 items, however.
-  MAX_CONCURRENT_BATCH_WRITING: 5   // Write a maximum of 5 batches to dynamo concurrently
+  MAX_CONCURRENT_BATCH_WRITING: 1   // Write a maximum of 1 batches to dynamo concurrently
 }
 
 const logsQueue = new PQueue({concurrency: LIMITS.MAX_CONCURRENT_BATCH_WRITING});

--- a/lib/dynamodb-integration.js
+++ b/lib/dynamodb-integration.js
@@ -8,7 +8,7 @@ import { debug } from './utils.js';
 const LIMITS = {
   MAX_EVENT_MSG_SIZE_BYTES: 400000,   // The real max size is 409,600, we leave some room for overhead on each message
   MAX_BATCH_SIZE_BYTES: 16000000,     // We leave some fudge factor here too. This shouldn't be reachable for 25 items, however.
-  MAX_CONCURRENT_BATCH_WRITING: 1   // Write a maximum of 1 batches to dynamo concurrently
+  MAX_CONCURRENT_BATCH_WRITING: 10   // Write a maximum of 10 batches to dynamo concurrently
 }
 
 const logsQueue = new PQueue({concurrency: LIMITS.MAX_CONCURRENT_BATCH_WRITING});
@@ -115,7 +115,7 @@ lib.upload = function(dynamodbClient, tableName, streamName, logEvents, options,
 function retrySubmit(dynamodbClient, payload, cb, times) {
     debug('retrying to upload', times, 'more times')
 
-    logsQueue.add(() => sendLogsToDynamoDb(dynamodbClient, payload, cb, times));
+    setTimeout(() => logsQueue.add(() => sendLogsToDynamoDb(dynamodbClient, payload, cb, times)), 1000);
 }
 
 export default lib;

--- a/lib/dynamodb-integration.js
+++ b/lib/dynamodb-integration.js
@@ -82,14 +82,14 @@ const hasUnprocessedItems = (data) => !isEmpty(data.UnprocessedItems);
 
 const isDynamoDbError = (err, data) => err || hasUnprocessedItems(data);
 
-const sendLogsToDynamoDb = (dynamodbClient, payload, cb, times = 10) => new Promise((resolve) => {
+const sendLogsToDynamoDb = (dynamodbClient, payload, cb, times = 3) => new Promise((resolve) => {
   dynamodbClient.send(new BatchWriteItemCommand(payload), function (err, data) {
     debug('sent to aws, err: ', err, ' data: ', data)
     if (isDynamoDbError(err, data) && times > 0) {
       debug('error during batchWriteItem', err, true)
 
       if (hasUnprocessedItems(data)) {
-        retrySubmit(dynamodbClient, {RequestItems: data.UnprocessedItems}, cb, times - 1)
+        retrySubmit(dynamodbClient, {RequestItems: data.UnprocessedItems}, cb, times)
       } else {
         retrySubmit(dynamodbClient, payload, cb, times - 1)
       }

--- a/lib/dynamodb-integration.js
+++ b/lib/dynamodb-integration.js
@@ -82,7 +82,7 @@ const hasUnprocessedItems = (data) => !isEmpty(data.UnprocessedItems);
 
 const isDynamoDbError = (err, data) => err || hasUnprocessedItems(data);
 
-const sendLogsToDynamoDb = (dynamodbClient, payload, cb, times = 5) => new Promise((resolve) => {
+const sendLogsToDynamoDb = (dynamodbClient, payload, cb, times = 10) => new Promise((resolve) => {
   dynamodbClient.send(new BatchWriteItemCommand(payload), function (err, data) {
     debug('sent to aws, err: ', err, ' data: ', data)
     if (isDynamoDbError(err, data) && times > 0) {
@@ -115,7 +115,7 @@ lib.upload = function(dynamodbClient, tableName, streamName, logEvents, options,
 function retrySubmit(dynamodbClient, payload, cb, times) {
     debug('retrying to upload', times, 'more times')
 
-    setTimeout(() => logsQueue.add(() => sendLogsToDynamoDb(dynamodbClient, payload, cb, times)), 1000);
+    logsQueue.add(() => sendLogsToDynamoDb(dynamodbClient, payload, cb, times));
 }
 
 export default lib;

--- a/lib/dynamodb-integration.js
+++ b/lib/dynamodb-integration.js
@@ -8,7 +8,7 @@ import { debug } from './utils.js';
 const LIMITS = {
   MAX_EVENT_MSG_SIZE_BYTES: 400000,   // The real max size is 409,600, we leave some room for overhead on each message
   MAX_BATCH_SIZE_BYTES: 16000000,     // We leave some fudge factor here too. This shouldn't be reachable for 25 items, however.
-  MAX_CONCURRENT_BATCH_WRITING: 10   // Write a maximum of 10 batches to dynamo concurrently
+  MAX_CONCURRENT_BATCH_WRITING: 5   // Write a maximum of 5 batches to dynamo concurrently
 }
 
 const logsQueue = new PQueue({concurrency: LIMITS.MAX_CONCURRENT_BATCH_WRITING});

--- a/lib/dynamodb-integration.js
+++ b/lib/dynamodb-integration.js
@@ -82,7 +82,7 @@ const hasUnprocessedItems = (data) => !isEmpty(data.UnprocessedItems);
 
 const isDynamoDbError = (err, data) => err || hasUnprocessedItems(data);
 
-const sendLogsToDynamoDb = (dynamodbClient, payload, cb, times = 3) => new Promise((resolve) => {
+const sendLogsToDynamoDb = (dynamodbClient, payload, cb, times = 5) => new Promise((resolve) => {
   dynamodbClient.send(new BatchWriteItemCommand(payload), function (err, data) {
     debug('sent to aws, err: ', err, ' data: ', data)
     if (isDynamoDbError(err, data) && times > 0) {


### PR DESCRIPTION
### Issue & Steps to Reproduce / Feature Request

Our transporter is still not resilient enough, some batches still have partial failures.

### Solution

When sending batch request to dynamo db we have two options for error:
1. An error object is returned from the request - meaning all the items in the batch failed.
2. The response has `UnprocessedItems` that is not empty - only some of the items failed (usually because of load).

My solution here is, when an error is partial error we won't reduce the retry times. That means that if we couldn't insert data because of load we will just try again.
If we have a record that is actually problematic we will actually get the error when its whole batch will fail.

I tried increasing the retry times but even with 10 we couldn't write 10k logs successfully.

### How I _manually_ verified it works
<!--
Think about the flows and features that are affected by this PR
-->
- [x] Ran 3 deployments with 10k logs and all went well