### PR TITLE
Fix: Do not use p queue and add better retry

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,13 @@
+{
+    "semi": true,
+    "singleQuote": true,
+    "printWidth": 120,
+    "trailingComma": "none",
+    "parser": "typescript",
+    "proseWrap": "preserve",
+    "quoteProps": "as-needed",
+    "doc": false,
+    "jsxBracketSameLine": true,
+    "arrowParens": "avoid"
+  }
+  

--- a/.prettierrc
+++ b/.prettierrc
@@ -10,4 +10,3 @@
     "jsxBracketSameLine": true,
     "arrowParens": "avoid"
   }
-  

--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 'use strict';
 
-
 import util from 'util';
 import winston from 'winston';
 import dynamodbIntegration from './lib/dynamodb-integration.js';
@@ -13,145 +12,140 @@ const defaultFlushTimeoutMs = 10_000;
 const maxMessageLength = 300_000;
 
 const WinstonDynamoDB = function (options) {
-    winston.Transport.call(this, options);
-    this.level = options.level || 'info';
-    this.name = options.name || 'DynamoDB';
-    this.tableName = options.tableName;
-    this.logStreamName = options.logStreamName;
-    this.options = options;
+  winston.Transport.call(this, options);
+  this.level = options.level || 'info';
+  this.name = options.name || 'DynamoDB';
+  this.tableName = options.tableName;
+  this.logStreamName = options.logStreamName;
+  this.options = options;
 
-    const messageFormatter = options.messageFormatter ? options.messageFormatter : function (log) {
-        return [log.level, log.message].join(' - ')
-    };
-    this.formatMessage = options.jsonMessage ? stringify : messageFormatter;
-    this.proxyServer = options.proxyServer;
-    this.uploadRate = options.uploadRate || 2000;
-    this.logEvents = [];
-    this.errorHandler = options.errorHandler;
+  const messageFormatter = options.messageFormatter
+    ? options.messageFormatter
+    : function (log) {
+        return [log.level, log.message].join(' - ');
+      };
+  this.formatMessage = options.jsonMessage ? stringify : messageFormatter;
+  this.proxyServer = options.proxyServer;
+  this.uploadRate = options.uploadRate || 2000;
+  this.logEvents = [];
+  this.errorHandler = options.errorHandler;
 
-    if (options.dynamoDbClient) {
-        this.dynamoDB = options.dynamoDbClient;
-    } else {
-        throw new Error("Pass configured DynamoDB client as 'dynamoDbClient' option");
-    }
+  if (options.dynamoDbClient) {
+    this.dynamoDB = options.dynamoDbClient;
+  } else {
+    throw new Error("Pass configured DynamoDB client as 'dynamoDbClient' option");
+  }
 
-    debug('constructor finished');
+  debug('constructor finished');
 };
 
 util.inherits(WinstonDynamoDB, winston.Transport);
 
 WinstonDynamoDB.prototype.log = function (info, callback) {
-    debug('log (called by winston)', info);
+  debug('log (called by winston)', info);
 
-    if (!isEmpty(info.message) || isError(info.message)) {
-        this.add(info);
-    }
+  if (!isEmpty(info.message) || isError(info.message)) {
+    this.add(info);
+  }
 
-    if (!/^uncaughtException: /.test(info.message)) {
-        // do not wait, just return right away
-        return callback(null, true);
-    }
+  if (!/^uncaughtException: /.test(info.message)) {
+    // do not wait, just return right away
+    return callback(null, true);
+  }
 
-    debug('message not empty, proceeding')
+  debug('message not empty, proceeding');
 
-    // clear interval and send logs immediately
-    // as Winston is about to end the process
-    clearInterval(this.intervalId);
-    this.intervalId = null;
-    this.submit(callback);
+  // clear interval and send logs immediately
+  // as Winston is about to end the process
+  clearInterval(this.intervalId);
+  this.intervalId = null;
+  this.submit(callback);
 };
 
 WinstonDynamoDB.prototype.createUploadInterval = function () {
-    this.intervalId = setInterval(() => {
-        this.submit();
-    }, this.uploadRate);
-}
+  this.intervalId = setInterval(() => {
+    this.submit();
+  }, this.uploadRate);
+};
 
 WinstonDynamoDB.prototype.add = function (log) {
-    debug('add log to queue', log);
+  debug('add log to queue', log);
 
-    const { message: originalMessage } = log;
+  const { message: originalMessage } = log;
 
-    if (isEmpty(originalMessage) || isError(originalMessage)) {
-        this.logEvents.push({
-            message: this.formatMessage(log),
-            timestamp: process.hrtime.bigint(),
-            rawMessage: log
-        });
+  if (isEmpty(originalMessage) || isError(originalMessage)) {
+    this.logEvents.push({
+      message: this.formatMessage(log),
+      timestamp: process.hrtime.bigint(),
+      rawMessage: log
+    });
+  } else if (originalMessage.length <= maxMessageLength) {
+    this.logEvents.push({
+      message: this.formatMessage(log),
+      timestamp: process.hrtime.bigint(),
+      rawMessage: log
+    });
+
+    if (this.logEvents.length >= dynamodbIntegration.MAX_BATCH_ITEM_NUM) {
+      debug('Max items for batch reached - submitting and rescheduling interval');
+      clearInterval(this.intervalId);
+      this.createUploadInterval();
+      this.submit();
     }
-    else if (originalMessage.length <= maxMessageLength) {
-        this.logEvents.push({
-            message: this.formatMessage(log),
-            timestamp: process.hrtime.bigint(),
-            rawMessage: log
-        });
+  } else {
+    for (let i = 0; i < originalMessage.length; i += maxMessageLength) {
+      let currentMessageSlice = originalMessage.slice(i, i + maxMessageLength);
+      this.logEvents.push({
+        message: this.formatMessage({ ...log, message: currentMessageSlice }),
+        timestamp: process.hrtime.bigint(),
+        rawMessage: log
+      });
 
-        if (this.logEvents.length >= dynamodbIntegration.MAX_BATCH_ITEM_NUM) {
-            debug('Max items for batch reached - submitting and rescheduling interval');
-            clearInterval(this.intervalId);
-            this.createUploadInterval();
-            this.submit();
-        }
+      debug(`Send each slice individually right away. current slice number:  ${i / maxMessageLength + 1}`);
+      clearInterval(this.intervalId);
+      this.createUploadInterval();
+      this.submit();
     }
-    else {
-        for (let i = 0; i < originalMessage.length; i += maxMessageLength) {
-            let currentMessageSlice = originalMessage.slice(i, i + maxMessageLength);
-            this.logEvents.push({
-                message: this.formatMessage({...log, message: currentMessageSlice}),
-                timestamp: process.hrtime.bigint(),
-                rawMessage: log
-            });
+  }
 
-            debug(`Send each slice individually right away. current slice number:  ${(i / maxMessageLength) + 1}`);
-            clearInterval(this.intervalId);
-            this.createUploadInterval();
-            this.submit();
-        }
-    }
-
-    if (!this.intervalId) {
-        debug('creating interval');
-        this.createUploadInterval()
-    }
+  if (!this.intervalId) {
+    debug('creating interval');
+    this.createUploadInterval();
+  }
 };
 
 WinstonDynamoDB.prototype.submit = function (callback) {
-    const defaultCallback = (err) => {
-        if (err) {
-            debug('error during submit', err, true);
-            this.errorHandler && this.errorHandler(err);
-        }
+  const defaultCallback = err => {
+    if (err) {
+      debug('error during submit', err, true);
+      this.errorHandler && this.errorHandler(err);
     }
-    callback = callback || defaultCallback;
+  };
+  callback = callback || defaultCallback;
 
-    const streamName = typeof this.logStreamName === 'function' ?
-        this.logStreamName() : this.logStreamName;
+  const streamName = typeof this.logStreamName === 'function' ? this.logStreamName() : this.logStreamName;
 
-    if (isEmpty(this.logEvents)) {
-        return callback();
-    }
+  if (isEmpty(this.logEvents)) {
+    return callback();
+  }
 
-    dynamodbIntegration.upload(
-        this.dynamoDB,
-        this.tableName,
-        streamName,
-        this.logEvents,
-        this.options,
-        callback
-    );
+  dynamodbIntegration.upload(this.dynamoDB, this.tableName, streamName, this.logEvents, this.options, callback);
 };
 
 WinstonDynamoDB.prototype.kthxbye = function (callback) {
-    clearInterval(this.intervalId);
-    this.intervalId = null;
-    this.flushTimeout = this.flushTimeout || (Date.now() + defaultFlushTimeoutMs);
+  clearInterval(this.intervalId);
+  this.intervalId = null;
+  this.flushTimeout = this.flushTimeout || Date.now() + defaultFlushTimeoutMs;
 
-    this.submit((function (error) {
-        if (error) return callback(error);
-        if (isEmpty(this.logEvents)) return callback();
-        if (Date.now() > this.flushTimeout) return callback(new Error('Timeout reached while waiting for logs to submit'));
-        else setTimeout(this.kthxbye.bind(this, callback), 0);
-    }).bind(this));
+  this.submit(
+    function (error) {
+      if (error) return callback(error);
+      if (isEmpty(this.logEvents)) return callback();
+      if (Date.now() > this.flushTimeout)
+        return callback(new Error('Timeout reached while waiting for logs to submit'));
+      else setTimeout(this.kthxbye.bind(this, callback), 0);
+    }.bind(this)
+  );
 };
 
 winston.transports.DynamoDB = WinstonDynamoDB;

--- a/lib/dynamodb-integration.js
+++ b/lib/dynamodb-integration.js
@@ -1,17 +1,13 @@
 import { BatchWriteItemCommand } from '@aws-sdk/client-dynamodb';
 import isUndefined from 'lodash.isundefined';
 import isEmpty from 'lodash.isempty';
-import PQueue from 'p-queue';
 import { debug } from './utils.js';
 
 
 const LIMITS = {
   MAX_EVENT_MSG_SIZE_BYTES: 400000,   // The real max size is 409,600, we leave some room for overhead on each message
   MAX_BATCH_SIZE_BYTES: 16000000,     // We leave some fudge factor here too. This shouldn't be reachable for 25 items, however.
-  MAX_CONCURRENT_BATCH_WRITING: 10   // Write a maximum of 10 batches to dynamo concurrently
 }
-
-const logsQueue = new PQueue({concurrency: LIMITS.MAX_CONCURRENT_BATCH_WRITING});
 
 // CloudWatch adds 26. DynamoDB doesn't, but we wanna add a constant size to each item
 // This size should depend on the attribute length and non-message values saved in DB
@@ -109,13 +105,13 @@ lib.upload = function(dynamodbClient, tableName, streamName, logEvents, options,
 
     debug('send to aws');
 
-    logsQueue.add(() => sendLogsToDynamoDb(dynamodbClient, payload, cb));
+    sendLogsToDynamoDb(dynamodbClient, payload, cb);
 };
 
 function retrySubmit(dynamodbClient, payload, cb, times) {
     debug('retrying to upload', times, 'more times')
 
-    logsQueue.add(() => sendLogsToDynamoDb(dynamodbClient, payload, cb, times));
+    sendLogsToDynamoDb(dynamodbClient, payload, cb, times);
 }
 
 export default lib;

--- a/lib/dynamodb-integration.js
+++ b/lib/dynamodb-integration.js
@@ -77,6 +77,8 @@ const hasUnprocessedItems = data => !isEmpty(data?.UnprocessedItems);
 
 const isDynamoDbError = (err, data) => err || hasUnprocessedItems(data);
 
+const sleep = async timeoutMs => await new Promise(resolve => setTimeout(() => resolve(), timeoutMs));
+
 const sendLogsToDynamoDb = (dynamodbClient, payload, cb, attempt = 1) =>
   new Promise(resolve => {
     dynamodbClient.send(new BatchWriteItemCommand(payload), async function (err, data) {
@@ -85,13 +87,16 @@ const sendLogsToDynamoDb = (dynamodbClient, payload, cb, attempt = 1) =>
       if (isDynamoDbError(err, data)) {
         debug('error during batchWriteItem', err, true);
         if (attempt > LIMITS.MAX_BATCH_WRITING_RETRIES) {
-          debug('Got to 3 attempts, not retrying.');
+          debug(`Got to ${LIMITS.MAX_BATCH_WRITING_RETRIES} attempts, not retrying.`);
           cb();
           resolve();
         }
 
-        await new Promise(resolve => setTimeout(() => resolve(), 500 * Math.pow(2, attempt - 1)));
+        // Wait before retry
+        const backoffMs = 500 * Math.pow(2, attempt - 1);
+        await sleep(backoffMs);
 
+        // Retry according to issue
         if (hasUnprocessedItems(data)) {
           sendLogsToDynamoDb(dynamodbClient, { RequestItems: data.UnprocessedItems }, cb, attempt + 1);
         } else {

--- a/lib/dynamodb-integration.js
+++ b/lib/dynamodb-integration.js
@@ -2,7 +2,6 @@ import { BatchWriteItemCommand } from '@aws-sdk/client-dynamodb';
 import isUndefined from 'lodash.isundefined';
 import isEmpty from 'lodash.isempty';
 import { debug } from './utils.js';
-import pRetry from 'p-retry';
 
 const LIMITS = {
   MAX_EVENT_MSG_SIZE_BYTES: 400000, // The real max size is 409,600, we leave some room for overhead on each message
@@ -73,27 +72,33 @@ const buildPayload = (tableName, streamName, events, additionalAttributesSchema)
   };
 };
 
-const hasUnprocessedItems = data => !isEmpty(data.UnprocessedItems);
+const hasUnprocessedItems = data => !isEmpty(data?.UnprocessedItems);
 
 const isDynamoDbError = (err, data) => err || hasUnprocessedItems(data);
 
-const sendLogsToDynamoDb = (dynamodbClient, payload, cb) =>
-  new Promise((resolve, reject) => {
-    dynamodbClient.send(new BatchWriteItemCommand(payload), function (err, data) {
+const sendLogsToDynamoDb = (dynamodbClient, payload, cb, attempt = 1) =>
+  new Promise(resolve => {
+    dynamodbClient.send(new BatchWriteItemCommand(payload), async function (err, data) {
       debug('sent to aws, err: ', err, ' data: ', data);
-      if (operation.retry(err))
-        if (isDynamoDbError(err, data)) {
-          debug('error during batchWriteItem', err, true);
 
-          if (hasUnprocessedItems(data)) {
-            reject(new Error('Partial batch failed', { payload: { RequestItems: data.UnprocessedItems } }));
-            retrySubmit(dynamodbClient, { RequestItems: data.UnprocessedItems }, cb, times - 1);
-          } else {
-            retrySubmit(dynamodbClient, payload, cb, times - 1);
-          }
-        } else {
+      if (isDynamoDbError(err, data)) {
+        debug('error during batchWriteItem', err, true);
+        if (attempt > 3) {
+          debug('Got to 3 attempts, not retrying.');
           cb();
+          resolve();
         }
+
+        await new Promise(resolve => setTimeout(() => resolve(), 500 * Math.pow(2, attempt - 1)));
+
+        if (hasUnprocessedItems(data)) {
+          sendLogsToDynamoDb(dynamodbClient, { RequestItems: data.UnprocessedItems }, cb, attempt + 1);
+        } else {
+          sendLogsToDynamoDb(dynamodbClient, payload, cb, attempt + 1);
+        }
+      } else {
+        cb();
+      }
 
       resolve();
     });
@@ -109,11 +114,5 @@ lib.upload = function (dynamodbClient, tableName, streamName, logEvents, options
 
   sendLogsToDynamoDb(dynamodbClient, payload, cb);
 };
-
-function retrySubmit(dynamodbClient, payload, cb, times) {
-  debug('retrying to upload', times, 'more times');
-
-  sendLogsToDynamoDb(dynamodbClient, payload, cb, times);
-}
 
 export default lib;

--- a/lib/dynamodb-integration.js
+++ b/lib/dynamodb-integration.js
@@ -5,7 +5,8 @@ import { debug } from './utils.js';
 
 const LIMITS = {
   MAX_EVENT_MSG_SIZE_BYTES: 400000, // The real max size is 409,600, we leave some room for overhead on each message
-  MAX_BATCH_SIZE_BYTES: 16000000 // We leave some fudge factor here too. This shouldn't be reachable for 25 items, however.
+  MAX_BATCH_SIZE_BYTES: 16000000, // We leave some fudge factor here too. This shouldn't be reachable for 25 items, however.
+  MAX_BATCH_WRITING_RETRIES: 5
 };
 
 // CloudWatch adds 26. DynamoDB doesn't, but we wanna add a constant size to each item
@@ -83,7 +84,7 @@ const sendLogsToDynamoDb = (dynamodbClient, payload, cb, attempt = 1) =>
 
       if (isDynamoDbError(err, data)) {
         debug('error during batchWriteItem', err, true);
-        if (attempt > 3) {
+        if (attempt > LIMITS.MAX_BATCH_WRITING_RETRIES) {
           debug('Got to 3 attempts, not retrying.');
           cb();
           resolve();

--- a/lib/dynamodb-integration.js
+++ b/lib/dynamodb-integration.js
@@ -2,116 +2,118 @@ import { BatchWriteItemCommand } from '@aws-sdk/client-dynamodb';
 import isUndefined from 'lodash.isundefined';
 import isEmpty from 'lodash.isempty';
 import { debug } from './utils.js';
-
+import pRetry from 'p-retry';
 
 const LIMITS = {
-  MAX_EVENT_MSG_SIZE_BYTES: 400000,   // The real max size is 409,600, we leave some room for overhead on each message
-  MAX_BATCH_SIZE_BYTES: 16000000,     // We leave some fudge factor here too. This shouldn't be reachable for 25 items, however.
-}
+  MAX_EVENT_MSG_SIZE_BYTES: 400000, // The real max size is 409,600, we leave some room for overhead on each message
+  MAX_BATCH_SIZE_BYTES: 16000000 // We leave some fudge factor here too. This shouldn't be reachable for 25 items, however.
+};
 
 // CloudWatch adds 26. DynamoDB doesn't, but we wanna add a constant size to each item
 // This size should depend on the attribute length and non-message values saved in DB
 const BASE_EVENT_SIZE_BYTES = 26;
 
-
 const lib = { MAX_BATCH_ITEM_NUM: 25 };
 
 const popEventsToSend = (logEvents, cb) => {
-    var entryIndex = 0;
-    var bytes = 0;
-    while (entryIndex < Math.min(logEvents.length, lib.MAX_BATCH_ITEM_NUM)) {
-        var ev = logEvents[entryIndex];
-        // unit tests pass null elements
-        var evSize = ev ? Buffer.byteLength(ev.message, 'utf8') + BASE_EVENT_SIZE_BYTES : 0;
-        if(evSize > LIMITS.MAX_EVENT_MSG_SIZE_BYTES) {
-            evSize = LIMITS.MAX_EVENT_MSG_SIZE_BYTES;
-            ev.message = ev.message.substring(0, evSize);
-            const msgTooBigErr = new Error('Message Truncated because it exceeds the DynamoDB size limit');
-            msgTooBigErr.logEvent = ev;
-            cb(msgTooBigErr);
-        }
-        if (bytes + evSize > LIMITS.MAX_BATCH_SIZE_BYTES) break;
-        bytes += evSize;
-        entryIndex++;
+  var entryIndex = 0;
+  var bytes = 0;
+  while (entryIndex < Math.min(logEvents.length, lib.MAX_BATCH_ITEM_NUM)) {
+    var ev = logEvents[entryIndex];
+    // unit tests pass null elements
+    var evSize = ev ? Buffer.byteLength(ev.message, 'utf8') + BASE_EVENT_SIZE_BYTES : 0;
+    if (evSize > LIMITS.MAX_EVENT_MSG_SIZE_BYTES) {
+      evSize = LIMITS.MAX_EVENT_MSG_SIZE_BYTES;
+      ev.message = ev.message.substring(0, evSize);
+      const msgTooBigErr = new Error('Message Truncated because it exceeds the DynamoDB size limit');
+      msgTooBigErr.logEvent = ev;
+      cb(msgTooBigErr);
     }
+    if (bytes + evSize > LIMITS.MAX_BATCH_SIZE_BYTES) break;
+    bytes += evSize;
+    entryIndex++;
+  }
 
-    return logEvents.splice(0, entryIndex);
-}
+  return logEvents.splice(0, entryIndex);
+};
 
-const buildPayload = (tableName, streamName, events, additionalAttributesSchema ) => {
-    var additionalAttributes = additionalAttributesSchema ? Object.entries(additionalAttributesSchema) : [];
-    return {
-      RequestItems: {
-        [tableName]: events.map((event) => {
-          const rawMessage = event.rawMessage;
-          const extraValues = {};
-          additionalAttributes.forEach(([key, dynamoValueType]) => {
-            if (!isUndefined(rawMessage[key])) {
-              extraValues[key] = {
-                [dynamoValueType]: rawMessage[key].toString(),
-              };
-            }
-          });
+const buildPayload = (tableName, streamName, events, additionalAttributesSchema) => {
+  var additionalAttributes = additionalAttributesSchema ? Object.entries(additionalAttributesSchema) : [];
+  return {
+    RequestItems: {
+      [tableName]: events.map(event => {
+        const rawMessage = event.rawMessage;
+        const extraValues = {};
+        additionalAttributes.forEach(([key, dynamoValueType]) => {
+          if (!isUndefined(rawMessage[key])) {
+            extraValues[key] = {
+              [dynamoValueType]: rawMessage[key].toString()
+            };
+          }
+        });
 
-          return {
-            PutRequest: {
-              Item: {
-                ...extraValues,
-                id: {
-                  S: streamName,
-                },
-                timestamp: {
-                  N: event.timestamp.toString(),
-                },
-                message: {
-                  S: event.message,
-                },
+        return {
+          PutRequest: {
+            Item: {
+              ...extraValues,
+              id: {
+                S: streamName
               },
-            },
-          };
-        }),
-      },
-    };
+              timestamp: {
+                N: event.timestamp.toString()
+              },
+              message: {
+                S: event.message
+              }
+            }
+          }
+        };
+      })
+    }
   };
+};
 
-const hasUnprocessedItems = (data) => !isEmpty(data.UnprocessedItems);
+const hasUnprocessedItems = data => !isEmpty(data.UnprocessedItems);
 
 const isDynamoDbError = (err, data) => err || hasUnprocessedItems(data);
 
-const sendLogsToDynamoDb = (dynamodbClient, payload, cb, times = 3) => new Promise((resolve) => {
-  dynamodbClient.send(new BatchWriteItemCommand(payload), function (err, data) {
-    debug('sent to aws, err: ', err, ' data: ', data)
-    if (isDynamoDbError(err, data) && times > 0) {
-      debug('error during batchWriteItem', err, true)
+const sendLogsToDynamoDb = (dynamodbClient, payload, cb) =>
+  new Promise((resolve, reject) => {
+    dynamodbClient.send(new BatchWriteItemCommand(payload), function (err, data) {
+      debug('sent to aws, err: ', err, ' data: ', data);
+      if (operation.retry(err))
+        if (isDynamoDbError(err, data)) {
+          debug('error during batchWriteItem', err, true);
 
-      if (hasUnprocessedItems(data)) {
-        retrySubmit(dynamodbClient, {RequestItems: data.UnprocessedItems}, cb, times - 1)
-      } else {
-        retrySubmit(dynamodbClient, payload, cb, times - 1)
-      }
-    } else {
-      cb()
-    }
+          if (hasUnprocessedItems(data)) {
+            reject(new Error('Partial batch failed', { payload: { RequestItems: data.UnprocessedItems } }));
+            retrySubmit(dynamodbClient, { RequestItems: data.UnprocessedItems }, cb, times - 1);
+          } else {
+            retrySubmit(dynamodbClient, payload, cb, times - 1);
+          }
+        } else {
+          cb();
+        }
 
-    resolve();
+      resolve();
+    });
   });
-})
 
-lib.upload = function(dynamodbClient, tableName, streamName, logEvents, options, cb) {
-    debug('upload', logEvents);
+lib.upload = function (dynamodbClient, tableName, streamName, logEvents, options, cb) {
+  debug('upload', logEvents);
 
-    const eventsToSend = popEventsToSend(logEvents, cb);
-    const payload = buildPayload(tableName, streamName, eventsToSend, options.additionalAttributesSchema);
+  const eventsToSend = popEventsToSend(logEvents, cb);
+  const payload = buildPayload(tableName, streamName, eventsToSend, options.additionalAttributesSchema);
 
-    debug('send to aws');
+  debug('send to aws');
 
-    sendLogsToDynamoDb(dynamodbClient, payload, cb);
+  sendLogsToDynamoDb(dynamodbClient, payload, cb);
 };
 
 function retrySubmit(dynamodbClient, payload, cb, times) {
-    debug('retrying to upload', times, 'more times')
+  debug('retrying to upload', times, 'more times');
 
-    sendLogsToDynamoDb(dynamodbClient, payload, cb, times);
+  sendLogsToDynamoDb(dynamodbClient, payload, cb, times);
 }
 
 export default lib;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -2,28 +2,30 @@ import chalk from 'chalk';
 import safeStringify from 'fast-safe-stringify';
 
 function handleErrorObject(key, value) {
-    if (value instanceof Error) {
-        return Object.getOwnPropertyNames(value).reduce(function(error, key) {
-            error[key] = value[key]
-            return error
-        }, {})
-    }
-    return value
+  if (value instanceof Error) {
+    return Object.getOwnPropertyNames(value).reduce(function (error, key) {
+      error[key] = value[key];
+      return error;
+    }, {});
+  }
+  return value;
 }
 
-export function stringify(o) { return safeStringify(o, handleErrorObject, '  '); }
+export function stringify(o) {
+  return safeStringify(o, handleErrorObject, '  ');
+}
 
 export function debug() {
-    if (!process.env.WINSTON_DYNAMODB_DEBUG) return;
-    const args = [].slice.call(arguments);
-    const lastParam = args.pop();
-    var color = chalk.red;
-    if (lastParam !== true) {
-        args.push(lastParam);
-        color = chalk.green;
-    }
+  if (!process.env.WINSTON_DYNAMODB_DEBUG) return;
+  const args = [].slice.call(arguments);
+  const lastParam = args.pop();
+  var color = chalk.red;
+  if (lastParam !== true) {
+    args.push(lastParam);
+    color = chalk.green;
+  }
 
-    args[0] = color(args[0]);
-    args.unshift(chalk.blue('DEBUG:'));
-    console.log.apply(console, args);
+  args[0] = color(args[0]);
+  args.unshift(chalk.blue('DEBUG:'));
+  console.log.apply(console, args);
 }

--- a/package.json
+++ b/package.json
@@ -22,9 +22,7 @@
     "fast-safe-stringify": "^2.0.7",
     "lodash.isempty": "^4.4.0",
     "lodash.iserror": "^3.1.1",
-    "lodash.isundefined": "^3.0.1",
-    "p-retry": "^6.2.1",
-    "retry": "^0.13.1"
+    "lodash.isundefined": "^3.0.1"
   },
   "devDependencies": {
     "prettier": "^3.5.1"

--- a/package.json
+++ b/package.json
@@ -22,6 +22,11 @@
     "fast-safe-stringify": "^2.0.7",
     "lodash.isempty": "^4.4.0",
     "lodash.iserror": "^3.1.1",
-    "lodash.isundefined": "^3.0.1"
+    "lodash.isundefined": "^3.0.1",
+    "p-retry": "^6.2.1",
+    "retry": "^0.13.1"
+  },
+  "devDependencies": {
+    "prettier": "^3.5.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "fast-safe-stringify": "^2.0.7",
     "lodash.isempty": "^4.4.0",
     "lodash.iserror": "^3.1.1",
-    "lodash.isundefined": "^3.0.1",
-    "p-queue": "^8.1.0"
+    "lodash.isundefined": "^3.0.1"
   }
 }


### PR DESCRIPTION
Using p-queue might use too much memory in case of many logs. To make the transporter more resilient without it we will do a few things:
1. Increase the retries amount from 3 to 5
2. Add exponential backoff

I also added prettier because why not

QAed by running 3 deployments with 10k logs with the new  transporter and see all these logs in the table